### PR TITLE
updated deprecation issues.

### DIFF
--- a/custom_components/bedjet/__init__.py
+++ b/custom_components/bedjet/__init__.py
@@ -4,11 +4,9 @@ async def async_setup(hass, config):
     return True
 
 async def async_setup_entry(hass, entry):
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "climate")
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, ["climate"])
     return True
 
 async def async_unload_entry(hass, entry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_forward_entry_unload(entry, "climate")
+    return await hass.config_entries.async_unload_platforms(entry, ["climate"])

--- a/custom_components/bedjet/manifest.json
+++ b/custom_components/bedjet/manifest.json
@@ -4,6 +4,6 @@
     "documentation": "https://github.com/asheliahut/ha-bedjet",
     "dependencies": [],
     "codeowners": ["@asheliahut"],
-    "version": "0.3.0",
+    "version": "0.4.0",
     "config_flow": true
 }


### PR DESCRIPTION
Fixed using these blogs

Link to Blog: https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/

Detected that custom integration 'bedjet' calls async_forward_entry_setup for integration

Detected that custom integration 'bedjet' sets option flow config_entry explicitly, which is deprecated at custom_components/bedjet/config_flow.py, line 39: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12, please report it to the author of the 'bedjet' custom integration